### PR TITLE
fix: Resolve relative import error in Docker

### DIFF
--- a/quicksave/app/main.py
+++ b/quicksave/app/main.py
@@ -8,7 +8,7 @@ from fasthtml.components import *
 from dotenv import load_dotenv
 from starlette.datastructures import UploadFile
 from starlette.responses import Response, RedirectResponse
-from .config import DB_PATH, DATA_DIR, TEMPLATES_DIR
+from config import DB_PATH, DATA_DIR, TEMPLATES_DIR
 
 # Load environment variables from .env file for local development
 load_dotenv()


### PR DESCRIPTION
Changed the relative import of the config module in main.py to an absolute import. This fixes the "ImportError: attempted relative import with no known parent package" that occurred when running the application in a Docker container with Gunicorn.